### PR TITLE
feat: add mobile-friendly menu for changing todo state

### DIFF
--- a/assets/styles/task-card-small.css
+++ b/assets/styles/task-card-small.css
@@ -20,15 +20,61 @@
 }
 
 .card-small-header {
-  border-radius: 8px;
-  color: var(--text-secondary);
-  width: fit-content;
-  padding: 4px 16px;
+  position: relative;
+  display: flex;
+  justify-content: space-between;
 }
 
 .card-small-header > p {
   font-size: 16px;
   line-height: 19.2px;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  padding: 4px 16px;
+}
+
+.btn-custom-more {
+  display: none;
+  justify-content: center;
+  align-items: center;
+}
+
+.btn-custom-more > img {
+  width: 24px;
+  height: 24px;
+  filter: invert(100%);
+}
+
+.btn-custom-more:hover,
+.btn-custom-more:focus,
+.btn-custom-more:active {
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.card-switch-state-menu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  max-width: 130px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  background: white;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 20px;
+  box-shadow: 0px 4px 4px 0px #00000040;
+  z-index: 100;
+}
+
+.card-switch-state-menu > button {
+  font-size: 14px;
+  text-align: start;
+}
+
+.card-switch-state-menu > p {
+  font-size: 16px;
 }
 
 .card-small-body {
@@ -144,4 +190,10 @@
   text-align: center;
   padding: 5px 0;
   z-index: 1;
+}
+
+@media (max-width: 1367px) {
+  .btn-custom-more {
+    display: flex;
+  }
 }

--- a/scripts/helper/taskcard.helper.js
+++ b/scripts/helper/taskcard.helper.js
@@ -55,6 +55,7 @@ function setProgressBarTooltip(taskIndex, taskSubTasks) {
 
   progressBar.title = `${subtasksText} done`;
   progressBar.addEventListener("click", (event) => {
+    event.stopPropagation();
     if (isTooltipVisible) return;
     const tooltip = document.createElement("div");
     tooltip.classList.add("tooltip");

--- a/scripts/templates/taskCardSmall.template.js
+++ b/scripts/templates/taskCardSmall.template.js
@@ -17,8 +17,14 @@
 function getTaskCardSmallTemplate(index, { category, description, priority, title, subTasks }) {
   return /*html*/ `
   <div class="task-card-small" id="task-card-small-${index}" onclick="openBigCardModal(${index})" draggable="true" ondragstart="startDraggingTodo(${index})">
-    <div class="card-small-header ${category === "Technical Task" ? "technical-task" : "user-story"}">
-      <p class="inter-extralight">${category}</p>
+    <div class="card-small-header">
+      <p class="inter-extralight ${category === "Technical Task" ? "technical-task" : "user-story"}">${category}</p>
+      <button onclick="openStateChangeMenu(event, ${index})" type="button" class="btn btn-custom-more">
+        <img src="./assets/svg/more-vert.svg" alt="More Icon">
+      </button>
+      <div id="card-switch-state-${index}" class="card-switch-state-menu d_none">
+        <p class="inter-medium">Move to:</p>
+      </div>
     </div>
       <div class="card-small-body">
         <div class="card-small-info">


### PR DESCRIPTION
- Added a menu button on the top right corner of small todo cards, visible only on mobile resolution.
- Menu allows users to change the state of the todo to "todo", "progress", "feedback", or "done".
- Feature addresses the limitations of drag and drop functionality on mobile devices.